### PR TITLE
Change GL ES to proper OpenGL ES word mark usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AndroidGL
-Android demos for GL ES with Java and C++ (NDK) 
+Android demos for OpenGL® ES with Java and C++ (NDK) 
 
 ##OpenGLJava 
-A GL ES 3.0 app that loads a model in json format and renders it. It can deal with textures, and shaders in separate files (located in assets folder).
+An OpenGL ES 3.0 app that loads a model in json format and renders it. It can deal with textures, and shaders in separate files (located in assets folder).
 
 ##OpenGLNDK
 [VSL](http://www.lighthouse3d.com/very-simple-libs/) has been ported to Android. This is a C++ demo app, using NDK, for OpenGL 3.0. It includes Assimp for model loading. Texture loading is achieved with JNI.


### PR DESCRIPTION
Update all instances of GL ES to OpenGL® ES according to Khronos trademark guidelines (https://www.khronos.org/legal/trademarks/)