### PR TITLE
Change GL ES to OpenGL® ES

### DIFF
--- a/OpenGLNDK/README.md
+++ b/OpenGLNDK/README.md
@@ -1,6 +1,6 @@
 #OpenGL with NDK 
 
-A GL ES 3.0 app in C++ using [VSL](http://www.lighthouse3d.com/very-simple-libs/). [Assimp](http://www.assimp.org/) is used to load models. Textures are loaded using JNI.
+An OpenGL® ES 3.0 app in C++ using [VSL](http://www.lighthouse3d.com/very-simple-libs/). [Assimp](http://www.assimp.org/) is used to load models. Textures are loaded using JNI.
 
 The starting point for this app was the code from hello-gl2, hello-libs, and gles3jni, available in [googlesamples/android-ndk](https://developer.android.com/training/graphics/opengl/index.html). The added/changed features are: 
 * arcball to control camera


### PR DESCRIPTION
Update GL ES to OpenGL® ES in accordance with Khronos trademark rules (https://www.khronos.org/legal/trademarks/)